### PR TITLE
Improve JSON import

### DIFF
--- a/server.js
+++ b/server.js
@@ -895,14 +895,14 @@ app.post("/importcharacter", urlencodedParser, function(request, response){
                     }
                     const jsonData = JSON.parse(data);
                     
-                    if(jsonData.char_name !== undefined){//json Pygmalion notepad
-                        png_name = getPngName(jsonData.char_name);
-                        var char = {"name": jsonData.char_name, "description": jsonData.char_persona, "personality": '', "first_mes": jsonData.char_greeting, "avatar": 'none', "chat": Date.now(), "mes_example": jsonData.example_dialogue, "scenario": jsonData.world_scenario, "create_date": Date.now()};
+                    if(jsonData.name !== undefined){
+                        png_name = getPngName(jsonData.name);
+                        var char = {"name": jsonData.name, "description": jsonData.description ?? '', "personality": jsonData.personality ?? '', "first_mes": jsonData.first_mes ?? '', "avatar": 'none', "chat": Date.now(), "mes_example": jsonData.mes_example ?? '', "scenario": jsonData.scenario ?? '', "create_date": Date.now()};
                         char = JSON.stringify(char);
                         charaWrite('./public/img/fluffy.png', char, png_name, response, {file_name: png_name});
-                    }else if(jsonData.name !== undefined){
-                        png_name = getPngName(jsonData.name);
-                        var char = {"name": jsonData.name, "description": jsonData.description, "personality": jsonData.personality, "first_mes": jsonData.first_mes, "avatar": 'none', "chat": Date.now(), "mes_example": '', "scenario": '', "create_date": Date.now()};
+                    }else if(jsonData.char_name !== undefined){//json Pygmalion notepad
+                        png_name = getPngName(jsonData.char_name);
+                        var char = {"name": jsonData.char_name, "description": jsonData.char_persona ?? '', "personality": '', "first_mes": jsonData.char_greeting ?? '', "avatar": 'none', "chat": Date.now(), "mes_example": jsonData.example_dialogue ?? '', "scenario": jsonData.world_scenario ?? '', "create_date": Date.now()};
                         char = JSON.stringify(char);
                         charaWrite('./public/img/fluffy.png', char, png_name, response, {file_name: png_name});
                     }else{


### PR DESCRIPTION
Currently, when TavernAI imports a JSON file it does not import all available fields.

If the JSON is in TavernAI format, then it ignores the `mes_example` and `scenario` properties and uses an empty string. The code also prefers Pygmalion format over the TavernAI format.

This PR makes the JSON importer prefer TavernAI format, as this format includes the `personality` property which the Pygmalion format lacks, as well as importing all properties the same way as the character card PNG importer does.
The code also checks each property for missing or null fields and imports them as empty strings, allowing it to better handle older style JSON files.
This brings its JSON handling in line with other tools and allows it to import a JSON file containing data in both TavernAI and Pygmalion formats.